### PR TITLE
Fixes Android error "illegal start of type"

### DIFF
--- a/src/main/java/me/neo/react/StatusBarPackage.java
+++ b/src/main/java/me/neo/react/StatusBarPackage.java
@@ -24,7 +24,7 @@ public class StatusBarPackage implements ReactPackage {
     }
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactApplicationContext) {
-        List<NativeModule> modules = new ArrayList<>();
+        List<NativeModule> modules = new ArrayList<NativeModule>();
         modules.add(new StatusBarModule(reactApplicationContext,mActivity));
         return modules;
     }


### PR DESCRIPTION
Fixes Android compilation error:

```
:react-native-android-statusbar:compileReleaseJavaWithJavac
/path/to/project/node_modules/react-native-android-statusbar/src/main/java/me/neo/react/StatusBarPackage.java:27: illegal start of type
        List<NativeModule> modules = new ArrayList<>();
                                                   ^
1 error
:react-native-android-statusbar:compileReleaseJavaWithJavac FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-android-statusbar:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
```
